### PR TITLE
ajout de 5 champs supplementaire au schema dans artworks

### DIFF
--- a/db/migrate/20211124114653_add_columns_to_artwork.rb
+++ b/db/migrate/20211124114653_add_columns_to_artwork.rb
@@ -1,0 +1,9 @@
+class AddColumnsToArtwork < ActiveRecord::Migration[6.0]
+  def change
+    add_column :artworks, :color_tags_api_file_id, :integer
+    add_column :artworks, :height, :integer
+    add_column :artworks, :width, :integer
+    add_column :artworks, :number_of_pixel_in_image, :integer
+    add_column :artworks, :colors, :json
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_11_23_145334) do
+ActiveRecord::Schema.define(version: 2021_11_24_114653) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -54,6 +54,11 @@ ActiveRecord::Schema.define(version: 2021_11_23_145334) do
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
     t.string "description"
+    t.integer "color_tags_api_file_id"
+    t.integer "height"
+    t.integer "width"
+    t.integer "number_of_pixel_in_image"
+    t.json "colors"
     t.index ["user_id"], name: "index_artworks_on_user_id"
   end
 


### PR DESCRIPTION
ajout de 5 champs supplementaire au schema dans artworks pour l'algo de decomposition d'image et donc mise a jour du shema avec une nouvelle migration "20211124114653_add_columns_to_artwork.rb"