### PR TITLE
fixed issues upload artwork

### DIFF
--- a/app/controllers/artworks_controller.rb
+++ b/app/controllers/artworks_controller.rb
@@ -28,17 +28,16 @@ class ArtworksController < ApplicationController
     @artwork = Artwork.new(artwork_params)
     @artwork.user = current_user
 
-    uploaded_file = UploadFileToApi.call(artwork_params[:photo])
+    if artwork_params[:photo].present?
+      uploaded_file = UploadFileToApi.call(artwork_params[:photo])
+      @artwork.color_tags_api_file_id = uploaded_file["file_id"]
+      report = GetColorTags.call(@artwork.color_tags_api_file_id)
+      @artwork.number_of_pixel_in_image = report["result"]["number_of_pixel_in_image"]
+      @artwork.width  = report["result"]["width"]
+      @artwork.height = report["result"]["height"]
+      @artwork.colors = report["result"]["colors"]
+    end
 
-    @artwork.color_tags_api_file_id = uploaded_file["file_id"]
-
-    report = GetColorTags.call(@artwork.color_tags_api_file_id)
-
-
-    @artwork.number_of_pixel_in_image = report["result"]["number_of_pixel_in_image"]
-    @artwork.width  = report["result"]["width"]
-    @artwork.height = report["result"]["height"]
-    @artwork.colors = report["result"]["colors"]
     if @artwork.save
       Artworks::ComputeScore.call(@artwork)
       redirect_to artwork_path(@artwork)

--- a/app/models/artwork.rb
+++ b/app/models/artwork.rb
@@ -6,5 +6,6 @@ class Artwork < ApplicationRecord
 
   validates :name, presence: true
   validates :description, presence: true
+  validates :photo, presence: true
   # validates :marketplace_url, presence: true
 end


### PR DESCRIPTION
Il est desormais possible d'oublier un champ dans le formulaire update an artwork sans quand cela provoque une erreur 500. LE champ manquant sera signifié en rouge afin que celui-ci soit rempli avant de continuer.